### PR TITLE
Allow flavor dialogs for infrastructure provisions to be sorted by size.

### DIFF
--- a/automate/CloudForms_Essentials/Service/Provisioning/StateMachines/Methods.class/__methods__/build_vm_provision_request.rb
+++ b/automate/CloudForms_Essentials/Service/Provisioning/StateMachines/Methods.class/__methods__/build_vm_provision_request.rb
@@ -407,7 +407,7 @@ def get_flavor(build, merged_options_hash, merged_tags_hash)
     log(:info, "cloud_flavor: #{cloud_flavor}") if cloud_flavor
   else
     # Manually map compute flavors for VMware, RHEV and SCVMM
-    case flavor_search_criteria.match(/\w*$/)[0]
+    case flavor_search_criteria.gsub(/^\d*_/, '').match(/\w*$/)[0]
     when 'xsmall';  flavor_name, number_of_sockets, cores_per_socket, vm_memory = 'xsmall', 1, 1, 1024
     when 'small';   flavor_name, number_of_sockets, cores_per_socket, vm_memory = 'small', 1, 1, 2048
     when 'medium';  flavor_name, number_of_sockets, cores_per_socket, vm_memory = 'medium', 1, 2, 4096

--- a/dialogs/miscellanous_dialogs.yml
+++ b/dialogs/miscellanous_dialogs.yml
@@ -466,18 +466,18 @@
         required_method_options: {}
         default_value: small
         values:
-        - - large
-          - Large - 4 vCPU x 8 GB RAM
-        - - medium
-          - Medium - 2 vCPU x 4 GB RAM
-        - - small
+        - - 01_small
           - Small - 1 vCPU x 2 GB RAM
-        - - xlarge
+        - - 02_medium
+          - Medium - 2 vCPU x 4 GB RAM
+        - - 03_large
+          - Large - 4 vCPU x 8 GB RAM
+        - - 04_xlarge
           - xLarge - 8 vCPU x 16 GB RAM
         values_method: 
         values_method_options: {}
         options:
-          :sort_by: :description
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 2
@@ -959,18 +959,18 @@
         required_method_options: {}
         default_value: small
         values:
-        - - large
-          - Large - 4 vCPU x 8 GB RAM
-        - - medium
-          - Medium - 2 vCPU x 4 GB RAM
-        - - small
+        - - 01_small
           - Small - 1 vCPU x 2 GB RAM
-        - - xlarge
+        - - 02_medium
+          - Medium - 2 vCPU x 4 GB RAM
+        - - 03_large
+          - Large - 4 vCPU x 8 GB RAM
+        - - 04_xlarge
           - xLarge - 8 vCPU x 16 GB RAM
         values_method: 
         values_method_options: {}
         options:
-          :sort_by: :description
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 2

--- a/dialogs/rhev_dialogs.yml
+++ b/dialogs/rhev_dialogs.yml
@@ -737,18 +737,18 @@
         required_method_options: {}
         default_value: xsmall
         values:
-        - - xsmall
+        - - 01_xsmall
           - xSmall (1x1)
-        - - small
+        - - 02_small
           - Small (1x2)
-        - - medium
+        - - 03_medium
           - Medium (2x4)
-        - - large
+        - - 04_large
           - Large (4x8)
         values_method: 
         values_method_options: {}
         options:
-          :sort_by: :none
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 3
@@ -1161,18 +1161,18 @@
         required_method_options: {}
         default_value: xsmall
         values:
-        - - xsmall
+        - - 01_xsmall
           - xSmall (1x1)
-        - - small
+        - - 02_small
           - Small (1x2)
-        - - medium
+        - - 03_medium
           - Medium (2x4)
-        - - large
+        - - 04_large
           - Large (4x8)
         values_method: 
         values_method_options: {}
         options:
-          :sort_by: :none
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 2

--- a/dialogs/vcenter_dialogs.yml
+++ b/dialogs/vcenter_dialogs.yml
@@ -515,20 +515,20 @@
         required_method_options: {}
         default_value: small
         values:
-        - - large
-          - Large - 2 vCPU x 4 GB RAM
-        - - medium
-          - Medium - 2 vCPU x 2 GB RAM
-        - - small
-          - Small - 1 vCPU x 1 GB RAM
-        - - xlarge
-          - XLarge - 4 vCPU x 4 GB RAM
-        - - xsmall
+        - - 01_xsmall
           - xSmall - 1 vCPU x 512 MB RAM
-        values_method: 
+        - - 02_small
+          - Small - 1 vCPU x 1 GB RAM
+        - - 03_medium
+          - Medium - 2 vCPU x 2 GB RAM
+        - - 04_large
+          - Large - 2 vCPU x 4 GB RAM
+        - - 05_xlarge
+          - XLarge - 4 vCPU x 4 GB RAM
+        values_method:
         values_method_options: {}
         options:
-          :sort_by: :description
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 2
@@ -1239,20 +1239,20 @@
         required_method_options: {}
         default_value: xsmall
         values:
-        - - large
-          - Large - 2 vCPU x 4 GB RAM
-        - - medium
-          - Medium - 2 vCPU x 2 GB RAM
-        - - small
-          - Small - 1 vCPU x 1 GB RAM
-        - - xlarge
-          - XLarge - 4 vCPU x 4 GB RAM
-        - - xsmall
+        - - 01_xsmall
           - xSmall - 1 vCPU x 512 MB RAM
-        values_method: 
+        - - 02_small
+          - Small - 1 vCPU x 1 GB RAM
+        - - 03_medium
+          - Medium - 2 vCPU x 2 GB RAM
+        - - 04_large
+          - Large - 2 vCPU x 4 GB RAM
+        - - 05_xlarge
+          - XLarge - 4 vCPU x 4 GB RAM
+        values_method:
         values_method_options: {}
         options:
-          :sort_by: :description
+          :sort_by: :value
           :sort_order: :ascending
         label: Flavor *
         position: 2


### PR DESCRIPTION
Use prefix on value field of any number of digits followed by a _.
build_vm_provision_request will strip these off.
Allows for sorting by value in service_dialogs, though this is still optional.
