### PR TITLE
Adding embedded Ansible dynamic dropdowns

### DIFF
--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_playbooks.rb
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_playbooks.rb
@@ -1,0 +1,37 @@
+# embedded_ansible_list_playbooks.rb
+#
+# Author: Joshua Cornutt <jcornutt@redhat.com>
+# License: GPL v3
+#
+# Description: List embedded Ansible playbook IDs.
+#
+
+begin
+  dialog_hash = Hash.new
+
+  # Find the Ansible repository object (if submitted)
+  repo_id = $evm.root['dialog_ansible_repo_id']
+  repo = $evm.vmdb(:ManageIQ_Providers_EmbeddedAnsible_AutomationManager_ConfigurationScriptSource).find_by_id(repo_id) rescue nil if repo_id
+  playbooks = repo.configuration_script_payloads rescue nil if repo
+
+  # Sanity checks
+  unless repo && playbooks
+    $evm.log(:warn, "User: #{$evm.root['user'].name} has no access to Playbooks for Repository ##{repo_id}")
+    exit MIQ_WARN
+  end
+
+  # Populate the dropdown values
+  playbooks.each { |playbook| dialog_hash[playbook.id] = playbook.name }
+
+  $evm.object['values'] = dialog_hash
+  $evm.log(:debug, "$evm.object['values']: #{$evm.object['values'].inspect}")
+
+  # Exit Method
+  exit (playbooks.empty?) ? MIQ_WARN : MIQ_OK
+
+# Set Ruby rescue behavior
+rescue => err
+  $evm.log(:error, "#{err.class} #{err}")
+  $evm.log(:error, "#{err.backtrace.join("\n")}")
+  exit MIQ_ABORT
+end

--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_playbooks.yaml
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_playbooks.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: embedded_ansible_list_playbooks
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_repositories.rb
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_repositories.rb
@@ -1,0 +1,34 @@
+# embedded_ansible_list_repositories.rb
+#
+# Author: Joshua Cornutt <jcornutt@redhat.com>
+# License: GPL v3
+#
+# Description: List embedded Ansible repository IDs.
+#
+
+begin
+  dialog_hash = Hash.new
+
+  # Find all embedded Ansible repositories
+  $evm.vmdb(:ManageIQ_Providers_EmbeddedAnsible_AutomationManager_ConfigurationScriptSource).all.each do |repo|
+    dialog_hash[repo.id] = repo.name
+  end
+
+  # Sanity check
+  if dialog_hash.blank?
+    $evm.log(:warn, "User: #{$evm.root['user'].name} has no access to Configuration Script Sources")
+    exit MIQ_WARN
+  end
+
+  $evm.object['values'] = dialog_hash
+  $evm.log(:debug, "$evm.object['values']: #{$evm.object['values'].inspect}")
+
+  # Exit Method
+  exit MIQ_OK
+
+# Set Ruby rescue behavior
+rescue => err
+  $evm.log(:error, "#{err.class} #{err}")
+  $evm.log(:error, "#{err.backtrace.join("\n")}")
+  exit MIQ_ABORT
+end

--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_repositories.yaml
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/__methods__/embedded_ansible_list_repositories.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: embedded_ansible_list_repositories
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/embedded_ansible_list_playbooks.yaml
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/embedded_ansible_list_playbooks.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Embedded Ansible - List Playbooks
+    name: embedded_ansible_list_playbooks
+    inherits: 
+    description: Lists playbooks by repository (expects "dialog_ansible_repo_id")
+  fields:
+  - execute:
+      value: embedded_ansible_list_playbooks

--- a/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/embedded_ansible_list_repositories.yaml
+++ b/automate/CloudForms_Essentials/Integration/RedHat/CloudForms/DynamicDialogs.class/embedded_ansible_list_repositories.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Embedded Ansible - List Repositories
+    name: embedded_ansible_list_repositories
+    inherits: 
+    description: Lists repositories
+  fields:
+  - execute:
+      value: embedded_ansible_list_repositories


### PR DESCRIPTION
Adding 2 new dynamic dropdowns to the list:

- embedded_ansible_list_repositories
- embedded_ansible_list_playbooks

I recently needed these for letting users select a playbook to run later in a state machine. 